### PR TITLE
Replace P2PK with P2PKH in comments

### DIFF
--- a/examples/create_p2sh_csv_p2pkh_address.py
+++ b/examples/create_p2sh_csv_p2pkh_address.py
@@ -31,7 +31,7 @@ def main():
 
     seq = Sequence(TYPE_RELATIVE_TIMELOCK, relative_blocks)
 
-    # secret key corresponding to the pubkey needed for the P2SH (P2PK) transaction
+    # secret key corresponding to the pubkey needed for the P2SH (P2PKH) transaction
     p2pkh_sk = PrivateKey('cRvyLwCPLU88jsyj94L7iJjQX5C2f8koG4G2gevN4BeSGcEvfKe9')
 
     # get the address (from the public key)

--- a/examples/spend_p2sh_csv_p2pkh.py
+++ b/examples/spend_p2sh_csv_p2pkh.py
@@ -37,7 +37,7 @@ def main():
     # create transaction input from tx id of UTXO (contained 11.1 tBTC)
     txin = TxInput(txid, vout, sequence=seq.for_input_sequence())
 
-    # secret key needed to spend P2PK that is wrapped by P2SH
+    # secret key needed to spend P2PKH that is wrapped by P2SH
     p2pkh_sk = PrivateKey('cRvyLwCPLU88jsyj94L7iJjQX5C2f8koG4G2gevN4BeSGcEvfKe9')
     p2pkh_pk = p2pkh_sk.get_public_key().to_hex()
     p2pkh_addr = p2pkh_sk.get_public_key().get_address()


### PR DESCRIPTION
Comments referred to P2PK, while it was actually P2PKH addresses.