### PR TITLE
Add a to_script_pub_key method in P2shAddress class

### DIFF
--- a/bitcoinutils/keys.py
+++ b/bitcoinutils/keys.py
@@ -869,6 +869,11 @@ class P2shAddress(Address):
     def __init__(self, address=None, hash160=None, script=None):
         super().__init__(address=address, hash160=hash160, script=script)
 
+    def to_script_pub_key(self):
+        """Returns the scriptPubKey (P2SH) that corresponds to this address"""
+        return bitcoinutils.script.Script(['OP_HASH160',
+                                           self.to_hash160(), 'OP_EQUAL'])
+
     def get_type(self):
         """Returns the type of address"""
         return P2SH_ADDRESS

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -127,6 +127,13 @@ class TestP2shAddresses(unittest.TestCase):
         script = Script([self.pub.to_hex(), 'OP_CHECKSIG'])
         addr = P2shAddress.from_script(script)
         self.assertTrue(addr.to_string(), self.p2sh_address)
+    
+    def test_p2shaddress_to_script_pub_key(self):
+        script = Script([self.pub.to_hex(), 'OP_CHECKSIG'])
+        fromScript = Script.to_p2sh_script_pub_key(script).to_hex()
+        addr = P2shAddress.from_script(script)
+        fromP2shAddress = addr.to_script_pub_key().to_hex()
+        self.assertTrue(fromScript, fromP2shAddress)
 
 
 class TestP2WPKHAddresses(unittest.TestCase):


### PR DESCRIPTION
A new method added to P2shAddress class in order to return the scriptPubKey (P2SH) that corresponds to the address