### PR TITLE
Fix data length bytes in op_push_data

### DIFF
--- a/bitcoinutils/script.py
+++ b/bitcoinutils/script.py
@@ -304,9 +304,9 @@ class Script:
         data_bytes = h_to_b(data)
 
         if len(data_bytes) < 0x4C:
-            return chr(len(data_bytes)).encode() + data_bytes
+            return bytes([len(data_bytes)]) + data_bytes
         elif len(data_bytes) < 0xFF:
-            return b"\x4c" + chr(len(data_bytes)).encode() + data_bytes
+            return b"\x4c" + bytes([len(data_bytes)]) + data_bytes
         elif len(data_bytes) < 0xFFFF:
             return b"\x4d" + struct.pack("<H", len(data_bytes)) + data_bytes
         elif len(data_bytes) < 0xFFFFFFFF:


### PR DESCRIPTION
`.encode()` will return 2 bytes when a one-byte encoded string is greater than 127, which will generate a wrong script.

```
In [1]: chr(128).encode()
Out[1]: b'\xc2\x80'
```