### PR TITLE
Handle ControlBlock Sign Bit

### DIFF
--- a/bitcoinutils/keys.py
+++ b/bitcoinutils/keys.py
@@ -626,7 +626,7 @@ class PublicKey:
 
     def to_taproot_hex(
         self, scripts: Optional[Script | list[Script] | list[list[Script]]] = None
-    ) -> str:
+    ) -> Tuple[str, bool]:
         """Returns the tweaked x coordinate of the public key as a hex string.
 
         Parameters
@@ -640,9 +640,11 @@ class PublicKey:
         tweak_int = calculate_tweak(self, scripts)
 
         # keep x-only coordinate
-        pubkey = tweak_taproot_pubkey(self.key.to_string(), tweak_int)[:32]
+        tweak_and_odd = tweak_taproot_pubkey(self.key.to_string(), tweak_int) 
+        pubkey = tweak_and_odd[0][:32]
+        is_odd = tweak_and_odd[1]
 
-        return pubkey.hex()
+        return pubkey.hex(), is_odd
 
     def is_y_even(self) -> bool:
         """Returns True if the y coordinate of the public key is even and
@@ -808,9 +810,11 @@ class PublicKey:
         tree
         """
 
-        pubkey = self.to_taproot_hex(scripts)
+        pubkey_and_is_odd = self.to_taproot_hex(scripts)
+        pubkey = pubkey_and_is_odd[0]
+        is_odd = pubkey_and_is_odd[1]
 
-        return P2trAddress(witness_program=pubkey)
+        return P2trAddress(witness_program=pubkey, is_odd=is_odd)
 
 
 class Address(ABC):
@@ -1325,8 +1329,11 @@ class P2trAddress(SegwitAddress):
         address: Optional[str] = None,
         witness_program: Optional[str] = None,  # script=None, ?
         version: str = P2TR_ADDRESS_V1,
+        is_odd: bool = False,
     ) -> None:
         """Allow creation only from witness program"""
+
+        self.odd = is_odd
 
         super().__init__(
             address=address,
@@ -1341,6 +1348,12 @@ class P2trAddress(SegwitAddress):
     def get_type(self) -> str:
         """Returns the type of address"""
         return self.version
+
+    def is_odd(self) -> bool:
+        """Returns True if the y coordinate of the public key is odd and
+        False otherwise."""
+
+        return self.odd
 
 
 def main():

--- a/bitcoinutils/keys.py
+++ b/bitcoinutils/keys.py
@@ -10,6 +10,11 @@
 # LICENSE file.
 
 from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Tuple
+
 import re
 import struct
 import hashlib

--- a/examples/spend_p2tr_single_script_by_script_path.py
+++ b/examples/spend_p2tr_single_script_by_script_path.py
@@ -111,7 +111,7 @@ def main():
     )
 
     # we spend a single script - no merkle path is required
-    control_block = ControlBlock(internal_pub)
+    control_block = ControlBlock(internal_pub, is_odd=to_address.is_odd())
 
     tx.witnesses.append(
         TxWitnessInput([sig, tr_script_p2pk.to_hex(), control_block.to_hex()])

--- a/examples/spend_p2tr_three_scripts_by_script_path.py
+++ b/examples/spend_p2tr_three_scripts_by_script_path.py
@@ -136,7 +136,7 @@ def main():
     leaf_c = tapleaf_tagged_hash(tr_script_p2pk_C)
 
     # we need to provide the merkle path (in bytes)
-    control_block = ControlBlock(internal_pub, scripts=leaf_a + leaf_c)
+    control_block = ControlBlock(internal_pub, scripts=leaf_a + leaf_c, is_odd=to_address.is_odd())
 
     tx.witnesses.append(
         TxWitnessInput([sig, tr_script_p2pk_B.to_hex(), control_block.to_hex()])

--- a/examples/spend_p2tr_two_scripts_by_script_path.py
+++ b/examples/spend_p2tr_two_scripts_by_script_path.py
@@ -124,7 +124,7 @@ def main():
     leaf_b = tapleaf_tagged_hash(tr_script_p2pk_B)
 
     # we need to provide the leaf_b hash as merkle path
-    control_block = ControlBlock(internal_pub, scripts=leaf_b)
+    control_block = ControlBlock(internal_pub, scripts=leaf_b, is_odd=to_address.is_odd())
 
     tx.witnesses.append(
         TxWitnessInput([sig, tr_script_p2pk_A.to_hex(), control_block.to_hex()])

--- a/tests/test_p2tr_txs.py
+++ b/tests/test_p2tr_txs.py
@@ -38,7 +38,7 @@ class TestCreateP2trTransaction(unittest.TestCase):
             "7b6412a0eed56338731e83c606f13ebb7a3756b3e4e1dbbe43a7db8d09106e56", 1
         )
         self.amount02 = to_satoshis(0.00005)
-        self.script_pubkey02 = Script(["OP_1", self.pub02.to_taproot_hex()])
+        self.script_pubkey02 = Script(["OP_1", self.pub02.to_taproot_hex()[0]])
         # same for 03
         self.toAddress02 = P2pkhAddress("mtVHHCqCECGwiMbMoZe8ayhJHuTdDbYWdJ")
         # same for 03
@@ -69,7 +69,7 @@ class TestCreateP2trTransaction(unittest.TestCase):
             "2a28f8bd8ba0518a86a390da310073a30b7df863d04b42a9c487edf3a8b113af", 1
         )
         self.amount02 = to_satoshis(0.00005)
-        self.script_pubkey03 = Script(["OP_1", self.pub03.to_taproot_hex()])
+        self.script_pubkey03 = Script(["OP_1", self.pub03.to_taproot_hex()[0]])
 
         self.raw_unsigned03 = (
             "02000000000101af13b1a8f3ed87c4a9424bd063f87d0ba3730031da90a3868a51a08bbdf8"
@@ -264,7 +264,7 @@ class TestCreateP2trWithSingleTapScript(unittest.TestCase):
             "99b84491534729bd5f4065bdcb42ed10fcd50340bf0a391574b56651923abdb25673105900"
             "8a08b5a3406cd81ce10ef5e7f936c6b9f7915ec1054e2a480e4552fa177aed868dc8b28c62"
             "63476871b21584690ef8222013f523102815e9fbbe132ffb8329b0fef5a9e4836d216dce18"
-            "24633287b0abc6ac21c01036a7ed8d24eac9057e114f22342ebf20c16d37f0d25cfd2c900b"
+            "24633287b0abc6ac21c11036a7ed8d24eac9057e114f22342ebf20c16d37f0d25cfd2c900b"
             "f401ec09c900000000"
         )
 
@@ -300,7 +300,7 @@ class TestCreateP2trWithSingleTapScript(unittest.TestCase):
             tapleaf_scripts=[self.tr_script_p2pk1],
             tweak=False,
         )
-        control_block = ControlBlock(self.from_pub2)
+        control_block = ControlBlock(self.from_pub2, is_odd=self.to_address2.is_odd())
         tx.witnesses.append(
             TxWitnessInput([sig, self.tr_script_p2pk1.to_hex(), control_block.to_hex()])
         )
@@ -361,7 +361,7 @@ class TestCreateP2trWithTwoTapScripts(unittest.TestCase):
             "99b84491534729bd5f4065bdcb42ed10fcd50340ab89d20fee5557e57b7cf85840721ef28d"
             "68e91fd162b2d520e553b71d604388ea7c4b2fcc4d946d5d3be3c12ef2d129ffb92594bc1f"
             "42cdaec8280d0c83ecc2222013f523102815e9fbbe132ffb8329b0fef5a9e4836d216dce18"
-            "24633287b0abc6ac41c01036a7ed8d24eac9057e114f22342ebf20c16d37f0d25cfd2c900b"
+            "24633287b0abc6ac41c11036a7ed8d24eac9057e114f22342ebf20c16d37f0d25cfd2c900b"
             "f401ec09c9682f0e85d59cb20fd0e4503c035d609f127c786136f276d475e8321ec9e77e6c"
             "00000000"
         )
@@ -380,7 +380,7 @@ class TestCreateP2trWithTwoTapScripts(unittest.TestCase):
             tweak=False,
         )
         leaf_b = tapleaf_tagged_hash(self.tr_script_p2pk_B)
-        control_block = ControlBlock(self.from_pub, scripts=leaf_b)
+        control_block = ControlBlock(self.from_pub, scripts=leaf_b, is_odd=self.to_address.is_odd())
         tx.witnesses.append(
             TxWitnessInput(
                 [sig, self.tr_script_p2pk_A.to_hex(), control_block.to_hex()]
@@ -453,7 +453,7 @@ class TestCreateP2trWithThreeTapScripts(unittest.TestCase):
             "99b84491534729bd5f4065bdcb42ed10fcd50340644e392f5fd88d812bad30e73ff9900cdc"
             "f7f260ecbc862819542fd4683fa9879546613be4e2fc762203e45715df1a42c65497a63edc"
             "e5f1dfe5caea5170273f2220e808f1396f12a253cf00efdf841e01c8376b616fb785c39595"
-            "285c30f2817e71ac61c01036a7ed8d24eac9057e114f22342ebf20c16d37f0d25cfd2c900b"
+            "285c30f2817e71ac61c11036a7ed8d24eac9057e114f22342ebf20c16d37f0d25cfd2c900b"
             "f401ec09c9ed9f1b2b0090138e31e11a31c1aea790928b7ce89112a706e5caa703ff7e0ab9"
             "28109f92c2781611bb5de791137cbd40a5482a4a23fd0ffe50ee4de9d5790dd100000000"
         )
@@ -477,7 +477,7 @@ class TestCreateP2trWithThreeTapScripts(unittest.TestCase):
         )
         leaf_a = tapleaf_tagged_hash(self.tr_script_p2pk_A)
         leaf_c = tapleaf_tagged_hash(self.tr_script_p2pk_C)
-        control_block = ControlBlock(self.from_pub, scripts=leaf_a + leaf_c)
+        control_block = ControlBlock(self.from_pub, scripts=leaf_a + leaf_c, is_odd=self.to_address.is_odd())
         tx.witnesses.append(
             TxWitnessInput(
                 [sig, self.tr_script_p2pk_B.to_hex(), control_block.to_hex()]


### PR DESCRIPTION
Hi @karask 

I was facing some problems when I was trying to reveal a script from a taproot with this error:
`-26: non-mandatory-script-verify-flag (Witness program hash mismatch)`

I think it might be related with this pending todo: https://github.com/karask/python-bitcoin-utils/blob/master/TODO#L13 that I'm trying to address here.

Also I think it might be related with this issue: https://github.com/karask/python-bitcoin-utils/issues/63

I'm not 100% sure if this is the proper solution but at least, it fixes the problem for me.
