### PR TITLE
Addressed TODOS in `test_keys.py` 

### DIFF
--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -95,8 +95,9 @@ class TestPublicKeys(unittest.TestCase):
         pub = PublicKey(self.public_key_hex)
         self.assertEqual(pub.get_address().to_hash160(), pub.to_hash160())
 
-    # TODO add test_pubkey_x_only(self)
-    # TODO add test_pubkey_x_only(self)
+    def test_pubkey_x_only(self):
+        pub = PublicKey(self.public_key_hex)
+        self.assertEqual(pub.to_x_only_hex(), self.public_key_hex[2:66])
 
 
 class TestP2pkhAddresses(unittest.TestCase):


### PR DESCRIPTION
Resolved TODOS in `test_keys.py`:
In `test_keys.py`, I have added the `test_pubkey_x_only` which checks the working of `to_x_only_hex()`. 




