### PR TITLE
Modified ControlBlock Class

### DIFF
--- a/TODO
+++ b/TODO
@@ -11,7 +11,6 @@ SEGWIT-related
 - segwit v0 and v1 address object instantiates from address, witness program and script
   . are all used? test?
 - add annex to signature hash (easy, just add in bytes or hex in the method and include)
-- ControlBlock does not automatically construct the merkle path (expects it as input)
 
 CLEAN UP 
 - utils' to_bytes used in from_raw -- clean/reuse appropriate one

--- a/bitcoinutils/utils.py
+++ b/bitcoinutils/utils.py
@@ -62,10 +62,10 @@ class ControlBlock:
     ----------
     pubkey : PublicKey
         the internal public key object
-    script_to_spend : Script
-        the tapscript leaf that we want to spend
     scripts : list[ list[Script] ]
         a list of list of Scripts describing the merkle tree of scripts to commit
+    merkle_path : bytes
+        the pre-calculated merkle path
 
     Methods
     -------
@@ -75,34 +75,27 @@ class ControlBlock:
         returns the control block as a hexadecimal string
     """
 
-    def __init__(self, pubkey: PublicKey, script_to_spend=None, scripts=None, is_odd = False):
+    def __init__(self, pubkey: PublicKey, scripts: None | list[list[Script]], merkle_path: bytes, is_odd=False):
         """
         Parameters
         ----------
         pubkey : PublicKey
             the internal public key object
-        script_to_spend : Script (ignored for now)
-            the tapscript leaf that we want to spend
-        scripts : bytes
-            concatenated path (leafs/branches) hashes in bytes
+        scripts : list[list[Script]]
+            a list of list of Scripts describing the merkle tree of scripts to commit
+        merkle_path : bytes
+            the pre-calculated merkle path
         """
-        # script_to_spend is ignored for now - needed for automatically
-        # constructing the merkle path
         self.pubkey = pubkey
-        self.script_to_spend = script_to_spend
         self.scripts = scripts
+        self.merkle_path = merkle_path
         self.is_odd = is_odd
 
     def to_bytes(self) -> bytes:
-        leaf_version = bytes([ (1 if self.is_odd else 0) + LEAF_VERSION_TAPSCRIPT])
+        leaf_version = bytes([(1 if self.is_odd else 0) + LEAF_VERSION_TAPSCRIPT])
         # x-only public key is required
         pub_key = bytes.fromhex(self.pubkey.to_x_only_hex())
-        merkle_path = b""
-        # get merkle path from scripts, if any
-        # TODO currently the manually constructed merkle path is passed
-        if self.scripts:
-            merkle_path = self.scripts  # manually constructed path
-        return leaf_version + pub_key + merkle_path
+        return leaf_version + pub_key + self.merkle_path
 
     def to_hex(self):
         """Converts object to hexadecimal string"""

--- a/examples/spend_p2tr_single_script_by_script_path.py
+++ b/examples/spend_p2tr_single_script_by_script_path.py
@@ -111,7 +111,8 @@ def main():
     )
 
     # we spend a single script - no merkle path is required
-    control_block = ControlBlock(internal_pub, is_odd=to_address.is_odd())
+    merkle_path = b""  # Add the pre-calculated merkle path here
+    control_block = ControlBlock(internal_pub, scripts=None, merkle_path=merkle_path, is_odd=to_address.is_odd())
 
     tx.witnesses.append(
         TxWitnessInput([sig, tr_script_p2pk.to_hex(), control_block.to_hex()])

--- a/examples/spend_p2tr_three_scripts_by_script_path.py
+++ b/examples/spend_p2tr_three_scripts_by_script_path.py
@@ -136,7 +136,7 @@ def main():
     leaf_c = tapleaf_tagged_hash(tr_script_p2pk_C)
 
     # we need to provide the merkle path (in bytes)
-    control_block = ControlBlock(internal_pub, scripts=leaf_a + leaf_c, is_odd=to_address.is_odd())
+    control_block = ControlBlock(internal_pub, all_leafs, b"".join([leaf_a, leaf_c]), is_odd=to_address.is_odd())
 
     tx.witnesses.append(
         TxWitnessInput([sig, tr_script_p2pk_B.to_hex(), control_block.to_hex()])

--- a/examples/spend_p2tr_two_scripts_by_script_path.py
+++ b/examples/spend_p2tr_two_scripts_by_script_path.py
@@ -124,7 +124,7 @@ def main():
     leaf_b = tapleaf_tagged_hash(tr_script_p2pk_B)
 
     # we need to provide the leaf_b hash as merkle path
-    control_block = ControlBlock(internal_pub, scripts=leaf_b, is_odd=to_address.is_odd())
+    control_block = ControlBlock(internal_pub, [tr_script_p2pk_B], leaf_b, is_odd=to_address.is_odd())
 
     tx.witnesses.append(
         TxWitnessInput([sig, tr_script_p2pk_A.to_hex(), control_block.to_hex()])

--- a/tests/test_p2tr_txs.py
+++ b/tests/test_p2tr_txs.py
@@ -300,7 +300,8 @@ class TestCreateP2trWithSingleTapScript(unittest.TestCase):
             tapleaf_scripts=[self.tr_script_p2pk1],
             tweak=False,
         )
-        control_block = ControlBlock(self.from_pub2, is_odd=self.to_address2.is_odd())
+        merkle_path = b""
+        control_block = ControlBlock(self.from_pub2, scripts=None, merkle_path=merkle_path, is_odd=self.to_address2.is_odd())
         tx.witnesses.append(
             TxWitnessInput([sig, self.tr_script_p2pk1.to_hex(), control_block.to_hex()])
         )
@@ -380,7 +381,8 @@ class TestCreateP2trWithTwoTapScripts(unittest.TestCase):
             tweak=False,
         )
         leaf_b = tapleaf_tagged_hash(self.tr_script_p2pk_B)
-        control_block = ControlBlock(self.from_pub, scripts=leaf_b, is_odd=self.to_address.is_odd())
+
+        control_block = ControlBlock(self.from_pub, [self.tr_script_p2pk_B], merkle_path=leaf_b, is_odd=self.to_address.is_odd())
         tx.witnesses.append(
             TxWitnessInput(
                 [sig, self.tr_script_p2pk_A.to_hex(), control_block.to_hex()]
@@ -477,7 +479,7 @@ class TestCreateP2trWithThreeTapScripts(unittest.TestCase):
         )
         leaf_a = tapleaf_tagged_hash(self.tr_script_p2pk_A)
         leaf_c = tapleaf_tagged_hash(self.tr_script_p2pk_C)
-        control_block = ControlBlock(self.from_pub, scripts=leaf_a + leaf_c, is_odd=self.to_address.is_odd())
+        control_block = ControlBlock(self.from_pub, scripts, b"".join([leaf_a, leaf_c]), is_odd=self.to_address.is_odd())
         tx.witnesses.append(
             TxWitnessInput(
                 [sig, self.tr_script_p2pk_B.to_hex(), control_block.to_hex()]


### PR DESCRIPTION
Based on the TODO file, it was mentioned that the ControlBlock class needed to be modified so that it does not automatically construct the merkle path (expects it as input). 

I modified the class so that it's new constructor looks as below - 

``` def __init__(self, pubkey: PublicKey, scripts: None | list[list[Script]], merkle_path: bytes, is_odd=False) ```

I am now taking all the scripts as input in form of a `List of Lists of Scripts`, it can be `None` as well in case that we are only spending out a single script in the transaction. The `merkle_path` is being taken as bytes in input which was the required task.

I also modified the files under the `examples` folder so that they are now consistent with new `ControlBlock` class.

Finally, I made sure that the `test_p2tr_txs.py` ran without throwing any errors and made necessary modification pertaining to the `ControlBlock` in that test.