### PR TITLE
Added to bitcoin-rpc lib option to ignore invalid ssl cert

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 The python-bitcoin-utils developers
+Copyright (c) 2018-2022 The python-bitcoin-utils developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bitcoinutils/bech32.py
+++ b/bitcoinutils/bech32.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2020 Pieter Wuille
+# Copyright (c) 2018, 2022 Pieter Wuille
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bitcoinutils/hdwallet.py
+++ b/bitcoinutils/hdwallet.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,6 @@
+[bitcoin]
+rpcuser=user
+rpcpassword=password
+rpchost=127.0.0.1
+rpcport=8332
+ignore_ssl_cert=true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Bitcoin Utilities"
-copyright = "2023, Konstantinos Karasavvas"
+copyright = "2022, Konstantinos Karasavvas"
 author = "Konstantinos Karasavvas"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/examples/hd_keys.py
+++ b/examples/hd_keys.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #

--- a/examples/send_to_p2tr_with_single_script.py
+++ b/examples/send_to_p2tr_with_single_script.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #

--- a/examples/send_to_p2tr_with_three_scripts.py
+++ b/examples/send_to_p2tr_with_three_scripts.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #

--- a/examples/send_to_p2tr_with_two_scripts.py
+++ b/examples/send_to_p2tr_with_two_scripts.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #

--- a/examples/spend_multi_input_p2tr_and_p2pkh.py
+++ b/examples/spend_multi_input_p2tr_and_p2pkh.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #

--- a/examples/spend_p2tr_default_path.py
+++ b/examples/spend_p2tr_default_path.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #

--- a/examples/spend_p2tr_single_script_by_key_path.py
+++ b/examples/spend_p2tr_single_script_by_key_path.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #

--- a/examples/spend_p2tr_single_script_by_script_path.py
+++ b/examples/spend_p2tr_single_script_by_script_path.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #

--- a/examples/spend_p2tr_three_scripts_by_script_path.py
+++ b/examples/spend_p2tr_three_scripts_by_script_path.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #

--- a/examples/spend_p2tr_two_scripts_by_script_path.py
+++ b/examples/spend_p2tr_two_scripts_by_script_path.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #

--- a/tests/test_p2tr_txs.py
+++ b/tests/test_p2tr_txs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 The python-bitcoin-utils developers
+# Copyright (C) 2018-2022 The python-bitcoin-utils developers
 #
 # This file is part of python-bitcoin-utils
 #


### PR DESCRIPTION
- [ ] needed to access remotely withut cert (for other validators from clients)
- [ ] Followed for reference https://github.com/jgarzik/python-bitcoinrpc/pull/50
- [ ] But not in a lib release yet,
- [ ] So added a config.ini option to optionally ignore cert so that it works when calling btcd remotely