### PR TITLE
Added to bitcoin-rpc lib option to ignore invalid ssl cert

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,6 @@
+[bitcoin]
+rpcuser=user
+rpcpassword=password
+rpchost=127.0.0.1
+rpcport=8332
+ignore_ssl_cert=true


### PR DESCRIPTION
- [ ] needed to access remotely without cert (for other validators from clients)
- [ ] Followed for reference https://github.com/jgarzik/python-bitcoinrpc/pull/50
- [ ] But not in a lib release yet,
- [ ] So added a config.ini option to optionally ignore cert so that it works when calling btcd remotely