### PR TITLE
Fix witness stack size to use encode_varint

### DIFF
--- a/bitcoinutils/transactions.py
+++ b/bitcoinutils/transactions.py
@@ -1058,7 +1058,7 @@ class Transaction:
         if has_segwit:
             for witness in self.witnesses:
                 # add witnesses script Count
-                witnesses_count_bytes = chr(len(witness.stack)).encode()
+                witnesses_count_bytes = encode_varint(len(witness.stack))
                 data += witnesses_count_bytes
                 data += witness.to_bytes()
         data += self.locktime


### PR DESCRIPTION
witness_count_bytes is incorrect when the witness stack has more than 127 elements. It should be computed as encode_varint as is done in lines 1050 and 1051 with txin_count_bytes and txout_count_bytes. 
I found the error in local using bitcoin core regtest. With this fix my transaction went through. 