### PR TITLE
Fix taproot hash computation

### DIFF
--- a/bitcoinutils/utils.py
+++ b/bitcoinutils/utils.py
@@ -115,8 +115,8 @@ def _generate_merkle_path(all_leafs, target_leaf_index):
 
     Returns
     ----------
-    merkle_path : list
-        List of tagged hashes representing the merkle path.
+    merkle_path : bytes
+        Tagged hash representing the merkle path.
     """
     traversed = 0
 


### PR DESCRIPTION
When hashing two branches in the taproot tree, the one containing the script that is going to be executed should always go first (we cannot just concatenate the two branches in order). Then, the current implementation for the example [ [A, B], C ] works for A and B. The problem is that for a huge tree with an arbitrary amount of leaves, the implementation only works for the two most leftmost leaves. The tests were correct since they checked spending from the first leaves. They'd failed when spending from C.