### PR TITLE
[FIX] Correction of from_bytes method doc string

### DIFF
--- a/bitcoinutils/keys.py
+++ b/bitcoinutils/keys.py
@@ -145,7 +145,7 @@ class PrivateKey:
 
     @classmethod
     def from_bytes(cls, b: bytes):
-        """Creates key from WIFC or WIF format key"""
+        """Creates a key directly from 32 raw bytes"""
 
         return cls(b=b)
 


### PR DESCRIPTION
doc string for form_bytes should be """Creates a key directly from 32 raw bytes""" not """Creates a key directly from 32 raw bytes""".