### PR TITLE
Add OP_CHECKSIGADD opcode support for Taproot script paths

### DIFF
--- a/bitcoinutils/script.py
+++ b/bitcoinutils/script.py
@@ -126,11 +126,13 @@ OP_CODES = {
     "OP_CHECKSIGVERIFY": b"\xad",
     "OP_CHECKMULTISIG": b"\xae",
     "OP_CHECKMULTISIGVERIFY": b"\xaf",
+    "OP_CHECKSIGADD": b"\xba",             # added this new OPCODE
     # locktime
     "OP_NOP2": b"\xb1",
     "OP_CHECKLOCKTIMEVERIFY": b"\xb1",
     "OP_NOP3": b"\xb2",
     "OP_CHECKSEQUENCEVERIFY": b"\xb2",
+    
 }
 
 CODE_OPS = {
@@ -221,6 +223,7 @@ CODE_OPS = {
     b"\xad": "OP_CHECKSIGVERIFY",
     b"\xae": "OP_CHECKMULTISIG",
     b"\xaf": "OP_CHECKMULTISIGVERIFY",
+    b"\xba": "OP_CHECKSIGADD", # added this new OPCODE
     # locktime
     b"\xb1": "OP_NOP2",
     b"\xb1": "OP_CHECKLOCKTIMEVERIFY",

--- a/tests/test_checksigadd.py
+++ b/tests/test_checksigadd.py
@@ -1,0 +1,12 @@
+import unittest
+from bitcoinutils.script import Script
+
+class TestCheckSigAdd(unittest.TestCase):
+    def test_checksigadd_opcode(self):
+        # Create a script with the new opcode
+        script = Script(["OP_CHECKSIGADD"])
+        # Check if it serializes correctly to hex
+        self.assertEqual(script.to_hex(), "ba")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds support for the OP_CHECKSIGADD opcode (0xba) which was introduced in BIP 342 with Taproot.

Changes:
- Added OP_CHECKSIGADD to the OP_CODES dictionary
- Added OP_CHECKSIGADD to the CODE_OPS dictionary
- Added a test case to verify correct serialization

This opcode is used in Taproot script paths for more efficient multisignature transactions.

Added a line to OP_CODES under the crypto section (line no 129)
<img width="1440" alt="Screenshot 2025-03-05 at 1 55 20 AM" src="https://github.com/user-attachments/assets/b8c87dc2-4cd7-4269-88b2-ae11122f6269" />

Added a line to CODE_OPS dictionary under the crypto section (line no 226)
<img width="1440" alt="Screenshot 2025-03-05 at 1 55 12 AM" src="https://github.com/user-attachments/assets/57fa76d8-e9ac-47cc-abb3-87dbf33756f9" />

Added a file to run the test case to verify the correct serialisation (test_script.py) 
<img width="1440" alt="Screenshot 2025-03-05 at 1 54 53 AM" src="https://github.com/user-attachments/assets/f74bc689-e768-4506-91d1-81ab7b6f82ff" />
