### PR TITLE
Fix of TODO regarding explicitly having to add the 00 byte for non segwit inputs in segwit transactions

### DIFF
--- a/bitcoinutils/transactions.py
+++ b/bitcoinutils/transactions.py
@@ -310,7 +310,7 @@ class TxOutput:
             txoutputraw = txoutputrawhex
         else:
             raise TypeError("Input must be a hexadecimal string or bytes")
-        
+
 
         # Unpack the amount of the TxOutput directly in bytes
         amount_format = "<Q"  # Little-endian unsigned long long (8 bytes)
@@ -493,6 +493,8 @@ class Transaction:
         Calculates the tx segwit size
     copy()
         creates a copy of the object (classmethod)
+    set_witness(txin_index, witness)
+        sets the witness for a particular input index
     get_transaction_digest(txin_index, script, sighash)
         returns the transaction input's digest that is to be signed according
     get_transaction_segwit_digest(txin_index, script, amount, sighash)
@@ -552,7 +554,7 @@ class Transaction:
             rawtx = rawtxhex
         else:
             raise TypeError("Input must be a hexadecimal string or bytes")
-        
+
 
         # Read version (4 bytes)
         version = rawtx[0:4]
@@ -638,6 +640,26 @@ class Transaction:
         outs = [TxOutput.copy(txout) for txout in tx.outputs]
         wits = [TxWitnessInput.copy(witness) for witness in tx.witnesses]
         return cls(ins, outs, tx.locktime, tx.version, tx.has_segwit, wits)
+
+    # this sets empty witness slots (if necessary)
+    # makes length of witness equal to the number of inputs, to prevent expliclty defining empty witness inputs
+    # for non segwit inputs
+    def set_witness(self, txin_index: int, witness: TxWitnessInput):
+        """Safely set a witness at the specified index"""
+        if not self.has_segwit:
+            raise RuntimeError(
+                "Transaction should be segwit in order to set segwit slots"
+            )
+        witness_len = len(self.witnesses)
+        input_len = len(self.inputs)
+        if witness_len < input_len:
+            # append empty witness inputs if input_len>witness_len
+            for _ in range(input_len - witness_len):
+                self.witnesses.append(TxWitnessInput([]))
+
+        if txin_index < 0 or txin_index >= len(self.inputs):
+            raise IndexError("txin_index out of range")
+        self.witnesses[txin_index] = witness
 
     def get_transaction_digest(
         self, txin_index: int, script: Script, sighash: int = SIGHASH_ALL

--- a/examples/spend_multi_input_p2tr_and_p2pkh.py
+++ b/examples/spend_multi_input_p2tr_and_p2pkh.py
@@ -84,12 +84,10 @@ def main():
     sig2 = priv2.sign_input(tx, 1, utxos_script_pubkeys[1])
     sig3 = priv3.sign_taproot_input(tx, 2, utxos_script_pubkeys, amounts)
 
-    tx.witnesses.append(TxWitnessInput([sig1]))
+    #set witness sets the witness at a particular input index
+    tx.set_witness(0, TxWitnessInput([sig1]))
     txin2.script_sig = Script([sig2, pub2.to_hex()])
-    # the second input is not segwit but we still need to add an empty
-    # witness input script
-    tx.witnesses.append(TxWitnessInput([]))
-    tx.witnesses.append(TxWitnessInput([sig3]))
+    tx.set_witness(2, TxWitnessInput([sig3]))
 
     # print raw signed transaction ready to be broadcasted
     print("\nRaw signed transaction:\n" + tx.serialize())

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for fil in ./examples/*.py; do 
+for fil in ./examples/*.py; do
   python $fil;
   sleep 2;
 done


### PR DESCRIPTION
This PR aims to solve the TODO where explicitly having to add an empty `TxWitnessInput` was necessary for compatibility. 
Changes: 
- I have created a new method `create_witness` that checks whether the length of the `witnesses` is same as `inputs`. 
- If it is not, then, since witnesses are added after inputs, I add empty `TxWitnessInput` that make the length equal, and then update the one corresponding to the `txin_index`. 
- Changed the example `spend_multi_input_p2tr_and_p2pkh` to use `create_witness` instead of manually changing the witness array. 

On running the updated version of the `spend_multi_input_p2tr_and_p2pkh.py` example and comparing it to before the implementation yields the same output, suggesting that the implementation is correct. Kindly review it and let me know if any changes are needed. 

Before: 
![before](https://github.com/user-attachments/assets/2bb5ceff-7aad-40a8-b92d-79afac288d84)
After: 
![after](https://github.com/user-attachments/assets/d880cecb-9555-4a9b-9b20-d365bdb447a9)

