### PR TITLE
Chore: Added byte support to from_hex functions

### DIFF
--- a/bitcoinutils/script.py
+++ b/bitcoinutils/script.py
@@ -12,7 +12,7 @@
 import copy
 import hashlib
 import struct
-from typing import Any
+from typing import Any, Union
 
 from bitcoinutils.ripemd160 import ripemd160
 from bitcoinutils.utils import b_to_h, h_to_b, vi_to_int
@@ -359,7 +359,7 @@ class Script:
         return b_to_h(self.to_bytes())
 
     @staticmethod
-    def from_raw(scriptrawhex: str, has_segwit: bool = False):
+    def from_raw(scriptrawhex: Union[str, bytes], has_segwit: bool = False):
         """
         Imports a Script commands list from raw hexadecimal data
             Attributes
@@ -369,7 +369,13 @@ class Script:
             has_segwit : boolean
                 Is the Tx Input segwit or not
         """
-        scriptraw = h_to_b(scriptrawhex)
+        if isinstance(scriptrawhex, str):
+            scriptraw = h_to_b(scriptrawhex)
+        elif isinstance(scriptrawhex, bytes):
+            scriptraw = scriptrawhex
+        else:
+            raise TypeError("Input must be a hexadecimal string or bytes")
+        
         commands = []
         index = 0
 

--- a/bitcoinutils/transactions.py
+++ b/bitcoinutils/transactions.py
@@ -12,7 +12,7 @@
 import math
 import hashlib
 import struct
-from typing import Optional
+from typing import Optional, Union
 
 from bitcoinutils.constants import (
     DEFAULT_TX_SEQUENCE,
@@ -141,7 +141,7 @@ class TxInput:
         return self.__str__()
 
     @staticmethod
-    def from_raw(txinputrawhex: str, cursor: int = 0, has_segwit: bool = False):
+    def from_raw(txinputrawhex: Union[str, bytes], cursor: int = 0, has_segwit: bool = False):
         """
         Imports a TxInput from a Transaction's hexadecimal data
 
@@ -154,7 +154,12 @@ class TxInput:
         has_segwit : boolean
             Is the Tx Input segwit or not
         """
-        txinputraw = h_to_b(txinputrawhex)
+        if isinstance(txinputrawhex, str):
+            txinputraw = h_to_b(txinputrawhex)
+        elif isinstance(txinputrawhex, bytes):
+            txinputraw = txinputrawhex
+        else:
+            raise TypeError("Input must be a hexadecimal string or bytes")
 
         # Unpack transaction ID (hash) in bytes and output index
         txid, vout = struct.unpack_from('<32sI', txinputraw, cursor)
@@ -286,7 +291,7 @@ class TxOutput:
         return data
 
     @staticmethod
-    def from_raw(txoutputrawhex: str, cursor: int = 0, has_segwit: bool = False):
+    def from_raw(txoutputrawhex: Union[str, bytes], cursor: int = 0, has_segwit: bool = False):
         """
         Imports a TxOutput from a Transaction's hexadecimal data
 
@@ -299,7 +304,13 @@ class TxOutput:
         has_segwit : boolean
             Is the Tx Output segwit or not
         """
-        txoutputraw = h_to_b(txoutputrawhex)
+        if isinstance(txoutputrawhex, str):
+            txoutputraw = h_to_b(txoutputrawhex)
+        elif isinstance(txoutputrawhex, bytes):
+            txoutputraw = txoutputrawhex
+        else:
+            raise TypeError("Input must be a hexadecimal string or bytes")
+        
 
         # Unpack the amount of the TxOutput directly in bytes
         amount_format = "<Q"  # Little-endian unsigned long long (8 bytes)
@@ -526,7 +537,7 @@ class Transaction:
         self.version = version
 
     @staticmethod
-    def from_raw(rawtxhex: str):
+    def from_raw(rawtxhex: Union[str, bytes]):
         """
         Imports a Transaction from hexadecimal data.
 
@@ -535,7 +546,13 @@ class Transaction:
         rawtxhex : string (hex)
             The hexadecimal raw string of the Transaction.
         """
-        rawtx = h_to_b(rawtxhex)
+        if isinstance(rawtxhex, str):
+            rawtx = h_to_b(rawtxhex)
+        elif isinstance(rawtxhex, bytes):
+            rawtx = rawtxhex
+        else:
+            raise TypeError("Input must be a hexadecimal string or bytes")
+        
 
         # Read version (4 bytes)
         version = rawtx[0:4]


### PR DESCRIPTION
This PR aims to introduce support of bytes inputs in `from_raw` functions throughout the codebase, by just checking the type before setting local variables. 

