### PR TITLE
Add example scripts for signing, combining, and finalizing multisig PSBTs

### DIFF
--- a/examples/combine_psbt.py
+++ b/examples/combine_psbt.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+"""
+Combine multiple PSBTs (Partially Signed Bitcoin Transactions) into a single PSBT with merged signatures and metadata.
+
+This script performs the combiner role defined in BIP-174, allowing multiple signers to contribute signatures separately,
+and then merge their PSBTs into one unified transaction.
+
+Features:
+- Loads multiple base64-encoded PSBTs
+- Merges all inputs, outputs, and partial signatures
+- Validates consistency across PSBTs before combining
+- Outputs a single combined PSBT in base64 format
+
+Usage:
+    python combine_psbt.py <psbt1_base64> <psbt2_base64> [<psbt3_base64> ...]
+
+Returns:
+    Combined PSBT with merged data from all inputs
+"""
+
+import sys
+from bitcoinutils.setup import setup
+from bitcoinutils.psbt import PSBT
+
+def main():
+    setup('testnet')
+    
+    if len(sys.argv) < 3:
+        print("Usage: python combine_psbt.py <psbt1_base64> <psbt2_base64> [psbt3_base64] ...")
+        return
+    
+    # Load PSBTs from command line arguments
+    psbts = [PSBT.from_base64(psbt_base64) for psbt_base64 in sys.argv[1:]]
+    
+    # Combine all PSBTs using the first one as base
+    combined_psbt = psbts[0].combine_psbts(psbts[1:])
+    
+    # Output the combined PSBT
+    print(combined_psbt.to_base64())
+
+if __name__ == "__main__":
+    main()

--- a/examples/finalize_psbt.py
+++ b/examples/finalize_psbt.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Finalize a PSBT (Partially Signed Bitcoin Transaction) to produce a broadcastable Bitcoin transaction.
+
+This script serves as the finalizer step (as defined in BIP-174), assembling signatures and scripts
+into a complete transaction ready for broadcast.
+
+Features:
+- Loads a base64-encoded PSBT from string or file
+- Finalizes all inputs by constructing scriptSig/scriptWitness
+- Optionally validates that all inputs are fully signed before finalization
+- Outputs the raw hex-encoded Bitcoin transaction
+
+Usage:
+    python finalize_psbt.py <psbt_base64_string>
+    python finalize_psbt.py --file <psbt_file.txt>
+    python finalize_psbt.py --file <psbt_file.txt> --validate
+
+Arguments:
+    <psbt_base64_string>        PSBT data as a base64-encoded string
+    --file <psbt_file.txt>      Load PSBT from a file
+    --validate                  (Optional) Enforce validation before finalizing
+
+Returns:
+    Hex-encoded, fully signed Bitcoin transaction ready for broadcast
+"""
+
+
+import argparse
+import base64
+import sys
+from bitcoinutils.setup import setup
+from bitcoinutils.psbt import PSBT
+
+
+def main():
+    """
+    Main function for PSBT finalization.
+    
+    Usage:
+        python finalize_psbt.py <psbt_base64_string>
+        python finalize_psbt.py --file <psbt_file.txt>
+        python finalize_psbt.py --file <psbt_file.txt> --validate
+    """
+    parser = argparse.ArgumentParser(description='Finalize a PSBT and create a transaction.')
+    parser.add_argument('psbt', nargs='?', help='Base64-encoded PSBT string')
+    parser.add_argument('--file', help='Text file containing base64 PSBT')
+    parser.add_argument('--validate', action='store_true', help='Validate finalized transaction')
+    parser.add_argument('--network', choices=['mainnet', 'testnet'], default='testnet', 
+                       help='Bitcoin network (default: testnet)')
+    
+    args = parser.parse_args()
+    
+    # Setup the library for specified network
+    setup(args.network)
+    
+    try:
+        # Load PSBT from input
+        if args.file:
+            with open(args.file, 'r') as f:
+                psbt_b64 = f.read().strip()
+        elif args.psbt:
+            psbt_b64 = args.psbt
+        else:
+            print("Error: Provide either base64 string or --file option.")
+            print("Use --help for usage information.")
+            return 1
+        
+        # Create PSBT object
+        psbt = PSBT.from_base64(psbt_b64)
+        
+        # Finalize the PSBT
+        if args.validate:
+            final_tx, validation = psbt.finalize(validate=True)
+            
+            print("Finalized Transaction (Hex):")
+            print(final_tx.serialize())
+            
+            print("\nValidation Report:")
+            print(f"Valid: {validation['valid']}")
+            print(f"Transaction ID: {validation['txid']}")
+            print(f"Size: {validation['size']} bytes")
+            print(f"Virtual Size: {validation['vsize']} vbytes")
+            
+            if validation['errors']:
+                print("Errors:")
+                for error in validation['errors']:
+                    print(f"  - {error}")
+            
+            if validation['warnings']:
+                print("Warnings:")
+                for warning in validation['warnings']:
+                    print(f"  - {warning}")
+                    
+        else:
+            final_tx = psbt.finalize(validate=False)
+            print("Finalized Transaction (Hex):")
+            print(final_tx.serialize())
+            
+        print(f"\nTransaction ready to broadcast!")
+        print(f"Use 'bitcoin-cli sendrawtransaction {final_tx.serialize()}' to broadcast")
+        
+        return 0
+        
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/sign_psbt.py
+++ b/examples/sign_psbt.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2025 The python-bitcoin-utils developers
+#
+# This file is part of python-bitcoin-utils
+#
+# It is subject to the license terms in the LICENSE file found in the top-level
+# directory of this distribution.
+#
+# No part of python-bitcoin-utils, including this file, may be copied,
+# modified, propagated, or distributed except according to the terms contained
+# in the LICENSE file.
+
+"""
+Sign a specific input of a PSBT (Partially Signed Bitcoin Transaction) using a WIF private key.
+
+This script allows targeted signing of one input in a PSBT, which is useful for multisig setups,
+hardware wallet integrations, or step-by-step signing processes.
+
+Features:
+- Loads a PSBT from a base64-encoded string
+- Signs a specified input using a provided WIF-formatted private key
+- Supports multiple script types: P2PKH, P2SH, P2WPKH, P2WSH, P2TR
+- Allows optional SIGHASH type customization (default: SIGHASH_ALL)
+
+Usage:
+    python sign_psbt.py <psbt_base64> <private_key_wif> <input_index> [sighash_type]
+
+Arguments:
+    psbt_base64       The PSBT in base64 encoding
+    private_key_wif   The private key in Wallet Import Format (WIF)
+    input_index       Index of the input to sign (0-based)
+    sighash_type      (Optional) Bitcoin SIGHASH flag (e.g., SIGHASH_ALL, SIGHASH_SINGLE)
+
+Returns:
+    Updated PSBT with the input partially signed and printed as base64
+"""
+
+
+import sys
+from bitcoinutils.setup import setup
+from bitcoinutils.keys import PrivateKey
+from bitcoinutils.psbt import PSBT
+from bitcoinutils.constants import SIGHASH_ALL
+
+
+def main():
+    """Main function for signing PSBT example."""
+    # Always call setup() first
+    setup('testnet')
+    
+    # Parse command line arguments
+    if len(sys.argv) < 4:
+        print("Usage: python sign_psbt.py <psbt_base64> <private_key_wif> <input_index> [sighash_type]")
+        print("\nExample:")
+        print("python sign_psbt.py <psbt> cTALNpTpRbbxTCJ2A5Vq88UxT44w1PE2cYqiB3n4hRvzyCev1Wwo 0")
+        sys.exit(1)
+    
+    psbt_base64 = sys.argv[1]
+    private_key_wif = sys.argv[2]
+    input_index = int(sys.argv[3])
+    sighash_type = int(sys.argv[4]) if len(sys.argv) > 4 else SIGHASH_ALL
+    
+    try:
+        # Load PSBT from base64
+        psbt = PSBT.from_base64(psbt_base64)
+        
+        # Load private key
+        private_key = PrivateKey.from_wif(private_key_wif)
+        
+        # Sign the specified input
+        success = psbt.sign_input(input_index, private_key, sighash_type)
+        
+        if success:
+            # Output the updated PSBT
+            print(psbt.to_base64())
+        else:
+            print("Failed to sign input", file=sys.stderr)
+            sys.exit(1)
+            
+    except Exception as e:
+        print(f"Error: {str(e)}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces three example scripts that demonstrate how to complete the full lifecycle of handling a 2-of-3 P2WSH multisig PSBT on Bitcoin testnet:

---

1. `sign_psbt.py`:
   - Signs a specific input of a base64-encoded PSBT using a private key in WIF format.
   - Accepts optional `sighash_type` argument (defaults to SIGHASH_ALL).
   - Provides CLI usage examples and structured error handling.

2. `combine_psbt.py`:
   - Combines multiple partially signed PSBTs (base64-encoded) into a single PSBT.
   - Uses the first PSBT as a base and merges subsequent ones.
   - Outputs the combined PSBT in base64 format.

3. `finalize_psbt.py`:
   - Finalizes a fully signed PSBT and generates the raw transaction hex.
   - Supports validation of the finalized transaction (including txid, size, vsize, warnings, and errors).
   - Accepts input via base64 string or from a file.
   - Clearly prints the final transaction hex and a broadcasting command.

---

These scripts are intended to complement the `create_multisig.py` script and complete the 2-of-3 multisig workflow:
> **Create → Sign → Combine → Finalize → Broadcast**

They follow a clean CLI interface, avoid test or mock data, and align with best practices for real testnet usage as discussed.

Each script depends on the updated PSBT class methods and is designed to be used as modular, testnet-ready tools.
