### PR TITLE
Add 4-leaf Taproot example with script path spend and README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,13 @@ https://github.com/karask/python-bitcoin-utils/blob/master/examples/send_to_p2tr
 Spend taproot from script path (has three alternative script path spends - A, B and C)
 https://github.com/karask/python-bitcoin-utils/blob/master/examples/spend_p2tr_three_scripts_by_script_path.py - single input, single output, spend script path B.
 
+Send to Taproot address that contains four script path spends
+https://github.com/aaron-recompile/python-bitcoin-utils/blob/taproot-4leaf-example/examples/send_to_p2tr_with_four_scripts.py - builds a Taproot address with four scripts (hashlock, multisig, CSV, siglock).
+
+Spend Taproot from script path (has four alternative script path spends - A, B, C, and D)
+https://github.com/aaron-recompile/python-bitcoin-utils/blob/taproot-4leaf-example/examples/spend_p2tr_four_scripts_by_script_path.py - spends from any of the 4 script paths using control blocks and full validation.
+
+
 Other
 -----
 

--- a/examples/send_to_p2tr_with_four_scripts.py
+++ b/examples/send_to_p2tr_with_four_scripts.py
@@ -1,0 +1,76 @@
+"""
+Example: Create a Taproot address with four leaf scripts (4-leaf Merkle tree)
+
+This demonstrates:
+- Hashlock using OP_SHA256
+- 2-of-2 multisig with CHECKSIGADD
+- CSV timelock (relative lock)
+- Simple CHECKSIG for fallback
+
+Author: Aaron Zhang (@aaron_recompile)
+"""
+
+from bitcoinutils.setup import setup
+from bitcoinutils.keys import PrivateKey
+from bitcoinutils.script import Script
+from bitcoinutils.transactions import Sequence
+
+import hashlib
+from bitcoinutils.constants import TYPE_RELATIVE_TIMELOCK
+
+
+
+def main():
+    setup('testnet')
+
+    # Alice's internal private key (for Taproot address)
+    alice_priv = PrivateKey("cNwW6ne3j9jUDWC3qFG5Bw3jzWvSZjZ2vgyP5LsTVj4WrJkJqjuz")
+    # Bob's private key, for multisig and CSV timelock script path
+    bob_priv = PrivateKey("cMrC8dGmStj3pz7mbY3vjwhXYcQwkcaWwV4QFCTF25WwVW1TCDkJ")
+
+    alice_pub = alice_priv.get_public_key()
+    bob_pub = bob_priv.get_public_key()    
+
+    # Script 1: Verify SHA256(preimage) == hash(helloworld)
+    hash1 = hashlib.sha256(b"helloworld").hexdigest()
+    script1 = Script(['OP_SHA256', hash1, 'OP_EQUALVERIFY', 'OP_TRUE'])
+
+    # Script 2: 2-of-2 multisig (using CHECKSIGADD)
+    script2 = Script([
+        "OP_0",
+        alice_pub.to_x_only_hex(),
+        "OP_CHECKSIGADD",
+        bob_pub.to_x_only_hex(),
+        "OP_CHECKSIGADD",
+        "OP_2", 
+        "OP_EQUAL"
+    ])
+
+    # Script 3: CSV timelock
+    relative_blocks = 2 # 2 blocks on testnet3, needs about 20 minutes to unlock
+    seq = Sequence(TYPE_RELATIVE_TIMELOCK, relative_blocks)
+    script3 = Script([
+        seq.for_script(),
+        "OP_CHECKSEQUENCEVERIFY",
+        "OP_DROP",
+        bob_pub.to_x_only_hex(),
+        "OP_CHECKSIG"
+    ]) 
+
+    # Script 4: Bob's siglock
+    script4 = Script([
+        bob_pub.to_x_only_hex(),
+        "OP_CHECKSIG"
+    ])
+    print(f"4th script hex: {script4.to_hex()}")        
+
+    # Build Merkle Tree
+    tree = [[script1, script2], [script3, script4]]
+
+    # Generate Taproot address
+    address = alice_pub.get_taproot_address(tree)
+    print("🪙 Please send funds to this Taproot address:", address.to_string())
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/spend_p2tr_four_scripts_by_script_path.py
+++ b/examples/spend_p2tr_four_scripts_by_script_path.py
@@ -1,0 +1,181 @@
+"""
+Example: Spend from a 4-leaf Taproot address via Script Path (Hashlock, Multisig, CSV, or Siglock)
+
+Merkle Tree Layout:
+         Merkle Root
+         /        \
+    Branch0      Branch1  
+   /      \      /      \
+S0       S1     S2      S3
+Hashlock Multi  CSV     Siglock
+
+This script allows spending from any of the four script paths using the correct ControlBlock and Witness stack.
+
+Author: Aaron Zhang (@aaron_recompile)
+"""
+
+from bitcoinutils.setup import setup
+from bitcoinutils.keys import PrivateKey
+from bitcoinutils.script import Script
+from bitcoinutils.transactions import Transaction, TxInput, TxOutput, TxWitnessInput, Sequence
+from bitcoinutils.utils import to_satoshis, ControlBlock
+from bitcoinutils.constants import TYPE_RELATIVE_TIMELOCK
+import hashlib
+
+def get_leaf_scripts(alice_pub, bob_pub):
+    preimage = "helloworld"
+    hashlock_script = Script([
+        'OP_SHA256',
+        hashlib.sha256(preimage.encode()).hexdigest(),
+        'OP_EQUALVERIFY',
+        'OP_TRUE'
+    ])
+
+    multisig_script = Script([
+        'OP_0',
+        alice_pub.to_x_only_hex(),
+        'OP_CHECKSIGADD',
+        bob_pub.to_x_only_hex(),
+        'OP_CHECKSIGADD',
+        'OP_2',
+        'OP_EQUAL'
+    ])
+
+    seq = Sequence(TYPE_RELATIVE_TIMELOCK, 2)
+    csv_script = Script([
+        seq.for_script(),
+        'OP_CHECKSEQUENCEVERIFY',
+        'OP_DROP',
+        bob_pub.to_x_only_hex(),
+        'OP_CHECKSIG'
+    ])
+
+    sig_script = Script([
+        bob_pub.to_x_only_hex(),
+        'OP_CHECKSIG'
+    ])
+
+    return [hashlock_script, multisig_script, csv_script, sig_script], preimage
+
+def main():
+    setup('testnet')
+
+    alice_priv = PrivateKey("cNwW6ne3j9jUDWC3qFG5Bw3jzWvSZjZ2vgyP5LsTVj4WrJkJqjuz")
+    bob_priv = PrivateKey("cMrC8dGmStj3pz7mbY3vjwhXYcQwkcaWwV4QFCTF25WwVW1TCDkJ")
+
+    alice_pub = alice_priv.get_public_key()
+    bob_pub = bob_priv.get_public_key()
+
+    scripts, preimage = get_leaf_scripts(alice_pub, bob_pub)
+    tree = [[scripts[0], scripts[1]], [scripts[2], scripts[3]]]
+    taproot_address = alice_pub.get_taproot_address(tree)
+    print("Taproot address:", taproot_address.to_string())
+
+    leaf_index = 3  # Input the index of the script to spend
+    tapleaf_script = scripts[leaf_index]
+ 
+    ctrl_block = ControlBlock(
+        alice_pub,
+        tree,
+        leaf_index,
+        is_odd=taproot_address.is_odd()
+    )
+
+    # Input your UTXO info here
+    prev_txid = "bd46ceabbe7cc0f2083cc58fc165daf8469d87b23795a1add3a7df78edfa639c"
+    vout = 1
+    input_amount = 6858
+    output_amount = 666
+    fee = 400
+    change_amount = input_amount - output_amount - fee
+
+    # Input your receiver address here
+    receiver_address = "tb1p647tfurqxqauaae4klwkwsaljn7yueg2692hasmp4a082cdtm4yqk2895f"
+
+    # Create transaction inputs and outputs
+    txin = TxInput(prev_txid, vout)
+    
+    # Create Script objects for both outputs
+    from bitcoinutils.keys import P2trAddress
+    receiver_script = P2trAddress(receiver_address).to_script_pub_key()
+    txout1 = TxOutput(output_amount, receiver_script)
+    txout2 = TxOutput(change_amount, taproot_address.to_script_pub_key())  # change back to same Taproot
+    tx = Transaction([txin], [txout1, txout2], has_segwit=True)
+
+    # Handle different script paths based on leaf_index
+    if leaf_index == 0:
+        # Hashlock script path
+        preimage_hex = preimage.encode('utf-8').hex()
+        witness = TxWitnessInput([
+            preimage_hex,
+            tapleaf_script.to_hex(),
+            ctrl_block.to_hex()
+        ])
+    elif leaf_index == 1:
+        # Multisig script path
+        sigB = bob_priv.sign_taproot_input(
+            tx, 0,
+            [taproot_address.to_script_pub_key()],
+            [input_amount],
+            script_path=True,
+            tapleaf_script=tapleaf_script,
+            tweak=False
+        )
+        sigA = alice_priv.sign_taproot_input(
+            tx, 0,
+            [taproot_address.to_script_pub_key()],
+            [input_amount],
+            script_path=True,
+            tapleaf_script=tapleaf_script,
+            tweak=False
+        )
+        witness = TxWitnessInput([
+            sigB, sigA,
+            tapleaf_script.to_hex(),
+            ctrl_block.to_hex()
+        ])
+    elif leaf_index == 2:
+        # CSV timelock script path - need to set sequence
+        seq = Sequence(TYPE_RELATIVE_TIMELOCK, 2)
+        seq_for_n_seq = seq.for_input_sequence()
+        assert seq_for_n_seq is not None
+        txin.sequence = seq_for_n_seq
+        
+        sig = bob_priv.sign_taproot_input(
+            tx, 0,
+            [taproot_address.to_script_pub_key()],
+            [input_amount],
+            script_path=True,
+            tapleaf_script=tapleaf_script,
+            tweak=False
+        )
+        witness = TxWitnessInput([
+            sig,
+            tapleaf_script.to_hex(),
+            ctrl_block.to_hex()
+        ])
+    elif leaf_index == 3:
+        # Simple siglock script path
+        sig = bob_priv.sign_taproot_input(
+            tx, 0,
+            [taproot_address.to_script_pub_key()],
+            [input_amount],
+            script_path=True,
+            tapleaf_script=tapleaf_script,
+            tweak=False
+        )
+        witness = TxWitnessInput([
+            sig,
+            tapleaf_script.to_hex(),
+            ctrl_block.to_hex()
+        ])
+    else:
+        raise Exception("Invalid leaf index")
+
+    tx.witnesses.append(witness)
+
+    print("Final transaction (raw):")
+    print(tx.serialize())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds an example of using Taproot with a 4-leaf script tree on Bitcoin testnet, covering both address generation and spending via script path.

**What's included:**
- `examples/send_to_p2tr_with_four_scripts.py`  
  Creates a Taproot address with 4 distinct leaf scripts:
  - Hashlock using `OP_SHA256`
  - 2-of-2 multisig using `OP_CHECKSIGADD`
  - CSV (relative timelock) using `OP_CHECKSEQUENCEVERIFY`
  - Simple `OP_CHECKSIG` (fallback)
  
- `examples/spend_p2tr_four_scripts_by_script_path.py`  
  Demonstrates spending from each of the 4 script paths. The correct control block and witness stack are generated for each path, and the transaction is signed using `sign_taproot_input()`.

- `README.rst` updated with links to the above examples and description.

This work aims to extend the library’s Taproot coverage with fully working testnet examples that can serve as both documentation and teaching material.