### PR TITLE
Documentation updates

### DIFF
--- a/docs/usage/segwit.rst
+++ b/docs/usage/segwit.rst
@@ -323,8 +323,8 @@ Script Path Spending
         tx, 0, 
         [prev_script_pubkey],
         [to_satoshis(0.001)],
-        ext_flag=1,  # Script path spending
-        script=tapscript
+        script_path=True,
+        tapleaf_script=tapscript
     )
 
     # Note: Actual witness data would include the signature, the script, 

--- a/docs/usage/segwit.rst
+++ b/docs/usage/segwit.rst
@@ -1,7 +1,7 @@
 SegWit Functionality
 ==================
 
-SegWit (Segregated Witness) is a Bitcoin protocol upgrade that separates transaction signatures from transaction data, resulting in several benefits such as increased transaction capacity and fixing transaction malleability.
+SegWit (Segregated Witness) is a Bitcoin protocol upgrade that separates witness data (signatures and scripts) from the rest of the transaction, resulting in several benefits such as increased transaction capacity and fixing transaction malleability.
 
 The Python Bitcoin Utils library provides comprehensive support for SegWit, including both version 0 (P2WPKH, P2WSH) and version 1 (Taproot/P2TR).
 
@@ -43,8 +43,8 @@ P2WSH (Pay to Witness Script Hash)
     from bitcoinutils.script import Script
 
     setup('testnet')
-    pub1 = PublicKey("public_key_1_hex")
-    pub2 = PublicKey("public_key_2_hex")
+    pub1 = PublicKey("03a1af804ac108a8a51782198c2d034b28bf90c8803f5a53f76276fa69a4eae77f")
+    pub2 = PublicKey("02530c548d402670b13ad8887ff99c294e67fc18097d236d57880c69261b42def7")
 
     # Create a 2-of-2 multisig redeem script
     redeem_script = Script(['OP_2', pub1.to_hex(), pub2.to_hex(), 'OP_2', 'OP_CHECKMULTISIG'])
@@ -78,8 +78,8 @@ P2SH-P2WSH
     from bitcoinutils.script import Script
 
     setup('testnet')
-    pub1 = PublicKey("public_key_1_hex")
-    pub2 = PublicKey("public_key_2_hex")
+    pub1 = PublicKey("03a1af804ac108a8a51782198c2d034b28bf90c8803f5a53f76276fa69a4eae77f")
+    pub2 = PublicKey("02530c548d402670b13ad8887ff99c294e67fc18097d236d57880c69261b42def7")
 
     # Create a 2-of-2 multisig redeem script
     redeem_script = Script(['OP_2', pub1.to_hex(), pub2.to_hex(), 'OP_2', 'OP_CHECKMULTISIG'])
@@ -120,7 +120,7 @@ Sending to a P2WPKH Address
     recipient_addr = P2wpkhAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx')
 
     # Create transaction input (from a previous P2PKH transaction)
-    txin = TxInput('previous_tx_id', 0)
+    txin = TxInput('a16f3ce4dd5deb92d98ef5cf8afeaf0775ebca408f708b2146c4fb42b41e14be', 0)
 
     # Create transaction output
     txout = TxOutput(to_satoshis(0.001), recipient_addr.to_script_pub_key())
@@ -129,8 +129,8 @@ Sending to a P2WPKH Address
     tx = Transaction([txin], [txout])
 
     # Sign the transaction
-    priv_key = PrivateKey('private_key_wif')
-    from_addr = P2pkhAddress('sender_p2pkh_address')
+    priv_key = PrivateKey('cTALNpTpRbbxTCJ2A5Zq6NwAnBSQjguuuhdyzLbWXDuA8ExBq58d')
+    from_addr = P2pkhAddress('n4bkvTyU1dVdzsrhWBqBw8fEMbHjJvtmJR')
     
     sig = priv_key.sign_input(
         tx, 0, 
@@ -157,10 +157,10 @@ Spending from a P2WPKH Address
     setup('testnet')
 
     # Create a transaction input (from a P2WPKH UTXO)
-    txin = TxInput('previous_tx_id', 0)
+    txin = TxInput('a16f3ce4dd5deb92d98ef5cf8afeaf0775ebca408f708b2146c4fb42b41e14be', 0)
 
     # Create a P2PKH address to send to
-    recipient_addr = P2pkhAddress('recipient_address')
+    recipient_addr = P2pkhAddress('n4bkvTyU1dVdzsrhWBqBw8fEMbHjJvtmJR')
 
     # Create transaction output
     txout = TxOutput(to_satoshis(0.0009), recipient_addr.to_script_pub_key())
@@ -169,7 +169,7 @@ Spending from a P2WPKH Address
     tx = Transaction([txin], [txout], has_segwit=True)
 
     # Prepare for signing
-    priv_key = PrivateKey('private_key_wif')
+    priv_key = PrivateKey('cTALNpTpRbbxTCJ2A5Zq6NwAnBSQjguuuhdyzLbWXDuA8ExBq58d')
     pub_key = priv_key.get_public_key()
     
     # For P2WPKH, the script code is the same as P2PKH scriptPubKey
@@ -194,7 +194,7 @@ P2WSH Transaction Example
 .. code-block:: python
 
     from bitcoinutils.setup import setup
-    from bitcoinutils.keys import PrivateKey, PublicKey, P2wshAddress
+    from bitcoinutils.keys import PrivateKey, P2pkhAddress
     from bitcoinutils.transactions import Transaction, TxInput, TxOutput, TxWitnessInput
     from bitcoinutils.script import Script
     from bitcoinutils.utils import to_satoshis
@@ -202,8 +202,8 @@ P2WSH Transaction Example
     setup('testnet')
 
     # Create a 2-of-2 multisig witness script
-    priv1 = PrivateKey('private_key_1_wif')
-    priv2 = PrivateKey('private_key_2_wif')
+    priv1 = PrivateKey('cTALNpTpRbbxTCJ2A5Zq6NwAnBSQjguuuhdyzLbWXDuA8ExBq58d')
+    priv2 = PrivateKey('cRvyLwCPLU88jsyj94L7iJjQX5C2f8koG4G2gevN4BeSGcEvfKe9')
     pub1 = priv1.get_public_key()
     pub2 = priv2.get_public_key()
     
@@ -211,8 +211,11 @@ P2WSH Transaction Example
         'OP_2', pub1.to_hex(), pub2.to_hex(), 'OP_2', 'OP_CHECKMULTISIG'
     ])
 
+    # Define recipient address
+    recipient_addr = P2pkhAddress('n4bkvTyU1dVdzsrhWBqBw8fEMbHjJvtmJR')
+
     # Spending from P2WSH
-    txin = TxInput('previous_p2wsh_tx_id', 0)
+    txin = TxInput('a16f3ce4dd5deb92d98ef5cf8afeaf0775ebca408f708b2146c4fb42b41e14be', 0)
     txout = TxOutput(to_satoshis(0.0009), recipient_addr.to_script_pub_key())
     
     tx = Transaction([txin], [txout], has_segwit=True)
@@ -230,6 +233,8 @@ P2WSH Transaction Example
         witness_script.to_hex()
     ]))
 
+    print(f"Signed transaction: {tx.serialize()}")
+
 Taproot Transactions
 -------------------
 
@@ -246,23 +251,26 @@ Key Path Spending
     setup('testnet')
 
     # Create transaction input from a P2TR UTXO
-    txin = TxInput('previous_tx_id', 0)
+    txin = TxInput('a16f3ce4dd5deb92d98ef5cf8afeaf0775ebca408f708b2146c4fb42b41e14be', 0)
 
     # Create a transaction output
-    recipient_addr = P2trAddress('recipient_taproot_address')
+    recipient_addr = P2trAddress('tb1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr')
     txout = TxOutput(to_satoshis(0.0009), recipient_addr.to_script_pub_key())
 
     # Create transaction with has_segwit=True
     tx = Transaction([txin], [txout], has_segwit=True)
 
     # Sign the taproot input using key path
-    priv_key = PrivateKey('private_key_wif')
-    prev_script_pubkey = priv_key.get_public_key().get_taproot_address().to_script_pub_key()
+    priv_key = PrivateKey('cTALNpTpRbbxTCJ2A5Zq6NwAnBSQjguuuhdyzLbWXDuA8ExBq58d')
+    
+    # Get the P2TR address and its scriptPubKey for this private key
+    taproot_addr = priv_key.get_public_key().get_taproot_address()
+    prev_script_pubkey = taproot_addr.to_script_pub_key()
     
     signature = priv_key.sign_taproot_input(
         tx, 0, 
         [prev_script_pubkey],  # List of all input script_pubkeys
-        [to_satoshis(0.001)]    # List of all input amounts
+        [to_satoshis(0.001)]   # List of all input amounts
     )
 
     # Set witness data for key path spending (only signature)
@@ -284,22 +292,32 @@ Script Path Spending
     setup('testnet')
 
     # Create transaction input from a P2TR UTXO
-    txin = TxInput('previous_tx_id', 0)
+    txin = TxInput('a16f3ce4dd5deb92d98ef5cf8afeaf0775ebca408f708b2146c4fb42b41e14be', 0)
 
     # Create a transaction output
-    recipient_addr = P2pkhAddress('recipient_address')
+    recipient_addr = P2pkhAddress('n4bkvTyU1dVdzsrhWBqBw8fEMbHjJvtmJR')
     txout = TxOutput(to_satoshis(0.0009), recipient_addr.to_script_pub_key())
 
     # Create transaction with has_segwit=True
     tx = Transaction([txin], [txout], has_segwit=True)
 
     # For script path spending, you need the taproot script
-    pub_key = PublicKey('public_key_hex')
+    pub_key = PublicKey('03a1af804ac108a8a51782198c2d034b28bf90c8803f5a53f76276fa69a4eae77f')
     tapscript = Script([pub_key.to_hex(), 'OP_CHECKSIG'])
     
     # Sign the taproot input using script path
-    priv_key = PrivateKey('private_key_wif')
-    prev_script_pubkey = Script(['OP_1', 'taproot_output_key_hex'])
+    priv_key = PrivateKey('cTALNpTpRbbxTCJ2A5Zq6NwAnBSQjguuuhdyzLbWXDuA8ExBq58d')
+    
+    # WARNING: This is a SIMPLIFIED EXAMPLE for illustration only!
+    # In production, the P2TR address must be properly constructed with:
+    # - An internal key (tweaked or untweaked)
+    # - A Merkle root derived from the script tree containing tapscript
+    # The address below is just a placeholder and won't work with the script above.
+    # See the library's taproot construction documentation for proper implementation.
+    
+    # For this example, we assume a P2TR address that was created with this script
+    taproot_addr = P2trAddress('tb1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr')
+    prev_script_pubkey = taproot_addr.to_script_pub_key()
     
     signature = priv_key.sign_taproot_input(
         tx, 0, 
@@ -309,9 +327,9 @@ Script Path Spending
         script=tapscript
     )
 
-    # Note: This is a simplified example. Actual witness data would include
-    # the signature, the script, and the control block.
-    # The control block computation would be handled by other library functions.
+    # Note: Actual witness data would include the signature, the script, 
+    # and the control block. The control block computation would be 
+    # handled by other library functions.
     
     print(f"Signed transaction: {tx.serialize()}")
 
@@ -338,7 +356,7 @@ In SegWit transactions, the witness data is stored separately from the transacti
 P2WPKH Witness
 ^^^^^^^^^^^^^
 
-.. code-block:: 
+.. code-block:: python
 
     [signature, public_key]
 
@@ -347,7 +365,7 @@ P2WSH Witness
 
 For multisig:
 
-.. code-block:: 
+.. code-block:: python
 
     ['', sig1, sig2, ..., sigN, witness_script]
 
@@ -356,21 +374,21 @@ Note: The empty string is required due to the CHECKMULTISIG off-by-one bug.
 P2TR Key Path Witness
 ^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: 
+.. code-block:: python
 
     [signature]
 
 P2TR Script Path Witness
 ^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: 
+.. code-block:: python
 
     [signature, script, control_block]
 
 Automatic Handling of Witness Data
 --------------------------------
 
-The library automatically handles witness format for different input types:
+The library handles witness format for different input types when using higher-level transaction construction functions:
 
 * For non-witness inputs in SegWit transactions, empty witnesses are added
 * For P2WPKH inputs, create a witness with signature and public key
@@ -385,7 +403,7 @@ When creating transactions with both SegWit and non-SegWit inputs:
 .. code-block:: python
 
     from bitcoinutils.setup import setup
-    from bitcoinutils.keys import PrivateKey, P2pkhAddress
+    from bitcoinutils.keys import PrivateKey, P2pkhAddress, P2wpkhAddress
     from bitcoinutils.transactions import Transaction, TxInput, TxOutput, TxWitnessInput
     from bitcoinutils.script import Script
     from bitcoinutils.utils import to_satoshis
@@ -394,14 +412,14 @@ When creating transactions with both SegWit and non-SegWit inputs:
 
     # Create transaction inputs
     # Non-SegWit input (P2PKH)
-    txin1 = TxInput('legacy_tx_id', 0)
+    txin1 = TxInput('a16f3ce4dd5deb92d98ef5cf8afeaf0775ebca408f708b2146c4fb42b41e14be', 0)
     # SegWit v0 input (P2WPKH)
-    txin2 = TxInput('segwit_v0_tx_id', 0)
+    txin2 = TxInput('75ddabb27b8845f5247975c8a5ba7c6f336c4570708ebe230caf6db5217ae858', 0)
     # Taproot input (P2TR)
-    txin3 = TxInput('taproot_tx_id', 0)
+    txin3 = TxInput('1dea7cd05979072a3578cab271c02244ea8a090bbb46aa680a65ecd027048d83', 0)
 
     # Create transaction output
-    recipient_addr = P2pkhAddress('recipient_address')
+    recipient_addr = P2pkhAddress('n4bkvTyU1dVdzsrhWBqBw8fEMbHjJvtmJR')
     txout = TxOutput(to_satoshis(0.0027), recipient_addr.to_script_pub_key())
 
     # Create transaction with has_segwit=True (required for any segwit inputs)
@@ -410,9 +428,9 @@ When creating transactions with both SegWit and non-SegWit inputs:
     # Sign each input with the appropriate method
     
     # 1. Legacy P2PKH input
-    priv_key1 = PrivateKey('legacy_priv_key_wif')
+    priv_key1 = PrivateKey('cTALNpTpRbbxTCJ2A5Zq6NwAnBSQjguuuhdyzLbWXDuA8ExBq58d')
     pub_key1 = priv_key1.get_public_key()
-    legacy_addr = P2pkhAddress('legacy_address')
+    legacy_addr = P2pkhAddress('n4bkvTyU1dVdzsrhWBqBw8fEMbHjJvtmJR')
     
     sig1 = priv_key1.sign_input(tx, 0, legacy_addr.to_script_pub_key())
     txin1.script_sig = Script([sig1, pub_key1.to_hex()])
@@ -420,7 +438,7 @@ When creating transactions with both SegWit and non-SegWit inputs:
     tx.witnesses.append(TxWitnessInput([]))
 
     # 2. SegWit v0 P2WPKH input
-    priv_key2 = PrivateKey('segwit_v0_priv_key_wif')
+    priv_key2 = PrivateKey('cRvyLwCPLU88jsyj94L7iJjQX5C2f8koG4G2gevN4BeSGcEvfKe9')
     pub_key2 = priv_key2.get_public_key()
     script_code2 = Script([
         'OP_DUP', 'OP_HASH160', 
@@ -432,13 +450,17 @@ When creating transactions with both SegWit and non-SegWit inputs:
     tx.witnesses.append(TxWitnessInput([sig2, pub_key2.to_hex()]))
 
     # 3. Taproot P2TR input (key path)
-    priv_key3 = PrivateKey('taproot_priv_key_wif')
+    priv_key3 = PrivateKey('cN9RbPMNcUwBzNNYa7cDJb2wPEKqCpCfe97KoHAWSdCDkqBTZ7tP')
+    
+    # Get proper scriptPubKeys for all inputs
+    segwit_addr = P2wpkhAddress.from_hash(pub_key2.to_hash160())
+    taproot_addr = priv_key3.get_public_key().get_taproot_address()
     
     # Collect all script_pubkeys and amounts for taproot signing
     all_script_pubkeys = [
         legacy_addr.to_script_pub_key(),
-        Script(['OP_0', pub_key2.to_hash160()]),  # P2WPKH scriptPubKey
-        Script(['OP_1', 'taproot_output_key_hex'])  # P2TR scriptPubKey
+        segwit_addr.to_script_pub_key(),  
+        taproot_addr.to_script_pub_key()
     ]
     all_amounts = [
         to_satoshis(0.001),  # Amount for input 0
@@ -459,19 +481,25 @@ Taproot introduces the new OP_CHECKSIGADD opcode for more efficient threshold mu
 .. code-block:: python
 
     from bitcoinutils.setup import setup
+    from bitcoinutils.keys import PublicKey
     from bitcoinutils.script import Script
 
     setup('testnet')
 
+    # Define public keys
+    pub1 = PublicKey('03a1af804ac108a8a51782198c2d034b28bf90c8803f5a53f76276fa69a4eae77f')
+    pub2 = PublicKey('02530c548d402670b13ad8887ff99c294e67fc18097d236d57880c69261b42def7')
+    pub3 = PublicKey('03e9f948b1bca68c97fd22cc52b6930ca4ed5b1bbaf14e52e95903726df26b814f')
+
     # Create a 2-of-3 multi-signature script using OP_CHECKSIGADD
     multi_sig_script = Script([
-        'pub_key1', 'OP_CHECKSIG',
-        'pub_key2', 'OP_CHECKSIGADD',
-        'pub_key3', 'OP_CHECKSIGADD',
+        pub1.to_hex(), 'OP_CHECKSIG',
+        pub2.to_hex(), 'OP_CHECKSIGADD',
+        pub3.to_hex(), 'OP_CHECKSIGADD',
         'OP_2', 'OP_EQUAL'
     ])
 
     # This is more efficient than the traditional way:
     traditional_multisig = Script([
-        'OP_2', 'pub_key1', 'pub_key2', 'pub_key3', 'OP_3', 'OP_CHECKMULTISIG'
+        'OP_2', pub1.to_hex(), pub2.to_hex(), pub3.to_hex(), 'OP_3', 'OP_CHECKMULTISIG'
     ])


### PR DESCRIPTION
# Fixed Issues:

- **Incomplete witness data setup**: Many examples showed signing but didn't properly set witness data
- **Mixed input transactions**: Corrected SegWit/non-SegWit signing in hybrid examples.
- **Imports**: Standardized missing imports (`TxWitnessInput`, `Script`, etc.) across all code blocks.
- **Method usage**: Resolved confusion between `sign_input` vs `sign_segwit_input`.
- **Script code clarity**: Improved explanation of script code for P2WPKH

## Key Improvements:

```
# Before - incomplete example:
sig = priv_key.sign_segwit_input(tx, 0, script_code, 0.001)
# Missing witness setup!

# After - complete example:
sig = priv_key.sign_segwit_input(tx, 0, script_code, amount)
tx.witnesses.append(TxWitnessInput([sig, pub_key.to_hex()]))
```